### PR TITLE
RDM-3878 update docker image name to definition-designer-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The following environment variables are required:
 
 | Name | Default | Description |
 |------|---------|-------------|
-| DEFINITION_STORE_DB_USERNAME | - | Username for database |
-| DEFINITION_STORE_DB_PASSWORD | - | Password for database |
-| DEFINITION_STORE_DB_USE_SSL | - | set to `true` if SSL is to be enabled. `false` recommended for local environments. |
-| DEFINITION_STORE_IDAM_KEY | - | Definition store's IDAM S2S micro-service secret key. This must match the IDAM instance it's being run against. |
-| DEFINITION_STORE_S2S_AUTHORISED_SERVICES | ccd_data,ccd_gw,ccd_admin,jui_webapp | Authorised micro-service names for S2S calls |
+| DEFINITION_DESIGNER_DB_USERNAME | - | Username for database |
+| DEFINITION_DESIGNER_DB_PASSWORD | - | Password for database |
+| DEFINITION_DESIGNER_DB_USE_SSL | - | set to `true` if SSL is to be enabled. `false` recommended for local environments. |
+| DEFINITION_DESIGNER_IDAM_KEY | - | Definition store's IDAM S2S micro-service secret key. This must match the IDAM instance it's being run against. |
+| DEFINITION_DESIGNER_S2S_AUTHORISED_SERVICES | ccd_gw,ccd_admin | Authorised micro-service names for S2S calls |
 | IDAM_USER_URL | - | Base URL for IdAM's User API service (idam-app). `http://localhost:4501` for the dockerised local instance or tunneled `dev` instance. |
 | IDAM_S2S_URL | - | Base URL for IdAM's S2S API service (service-auth-provider). `http://localhost:4502` for the dockerised local instance or tunneled `dev` instance. |
 | USER_PROFILE_HOST | - | Base URL for the User Profile service. `http://localhost:4453` for the dockerised local instance. |
@@ -84,7 +84,7 @@ Database will get initiated when you run `docker-compose up` for the first time 
 
 You don't need to migrate database manually since migrations are executed every time `docker-compose up` is executed.
 
-You can connect to the database at `http://localhost:5451` with the username and password set in the environment variables.
+You can connect to the database at `http://localhost:5453` with the username and password set in the environment variables.
 
 ## Modules
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       context: .
     image: hmcts/ccd-definition-designer-api
     environment:
-      - DEFINITION_STORE_DB_HOST=ccd-definition-store-database
-      - DEFINITION_STORE_DB_PORT=5432
-      - DEFINITION_STORE_DB_USERNAME
-      - DEFINITION_STORE_DB_PASSWORD
-      - DEFINITION_STORE_IDAM_KEY
-      - DEFINITION_STORE_S2S_AUTHORISED_SERVICES=ccd_data,ccd_gw
+      - DEFINITION_DESIGNER_DB_HOST=ccd-definition-designer-database
+      - DEFINITION_DESIGNER_DB_PORT=5432
+      - DEFINITION_DESIGNER_DB_USERNAME
+      - DEFINITION_DESIGNER_DB_PASSWORD
+      - DEFINITION_DESIGNER_IDAM_KEY
+      - DEFINITION_DESIGNER_S2S_AUTHORISED_SERVICES=ccd_admin,ccd_gw
       - USER_PROFILE_HOST
       - IDAM_USER_URL
       - IDAM_S2S_URL
@@ -22,25 +22,25 @@ services:
     ports:
       - 4454:4454
     depends_on:
-      - ccd-definition-store-database
+      - ccd-definition-designer-database
     links:
-      - ccd-definition-store-database
+      - ccd-definition-designer-database
 
-  ccd-definition-store-database:
+  ccd-definition-designer-database:
     build:
       context: docker/database
-    image: hmcts/ccd-definition-store-database
+    image: hmcts/ccd-definition-designer-database
     healthcheck:
       interval: 10s
       timeout: 10s
       retries: 10
     environment:
-      - DEFINITION_STORE_DB_USERNAME
-      - DEFINITION_STORE_DB_PASSWORD
+      - DEFINITION_DESIGNER_DB_USERNAME
+      - DEFINITION_DESIGNER_DB_PASSWORD
     ports:
-      - 5451:5432
+      - 5453:5432
     volumes:
-      - ccd-definition-store-database-data:/var/lib/postgresql/data
+      - ccd-definition-designer-database-data:/var/lib/postgresql/data
 
 volumes:
-  ccd-definition-store-database-data:
+  ccd-definition-designer-database-data:


### PR DESCRIPTION
### JIRA link (if applicable) ###

RDM-3878

### Change description ###

update docker image name to definition-designer-api

After running 
$ docker-compose build

Building ccd-definition-designer-database
Step 1/4 : FROM postgres:9.6
 ---> 392454116c27
Step 2/4 : COPY init-db.sh /docker-entrypoint-initdb.d
 ---> Using cache
 ---> fbbb31bc9924
Step 3/4 : HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD psql -c 'select 1' -d ccd_definition -U ${DEFINITION_STORE_DB_USERNAME}
 ---> Using cache
 ---> dbe38b1a209d
Step 4/4 : EXPOSE 5432
 ---> Using cache
 ---> 56e03280c6af
Successfully built 56e03280c6af
Successfully tagged hmcts/ccd-definition-designer-database:latest
Building ccd-definition-designer-api
Step 1/9 : FROM hmcts/cnp-java-base:openjdk-8u181-jre-alpine3.8-1.0
 ---> 4ee39465a32a
Step 2/9 : LABEL maintainer="https://github.com/hmcts/ccd-definition-designer-api"
 ---> Using cache
 ---> d9d2804acca6
Step 3/9 : ENV APP case-definition-designer-api.jar
 ---> Using cache
 ---> a22d214b866e
Step 4/9 : ENV APPLICATION_TOTAL_MEMORY 950M
 ---> Using cache
 ---> 2473bd025ad4
Step 5/9 : ENV APPLICATION_SIZE_ON_DISK_IN_MB 90
 ---> Using cache
 ---> 6faa41205311
Step 6/9 : ENV JAVA_OPTS "-Djava.security.egd=file:/dev/./urandom"
 ---> Using cache
 ---> 20f2ba7961f6
Step 7/9 : COPY build/libs/$APP /opt/app/
 ---> Using cache
 ---> 7603e0686c5b
Step 8/9 : HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD http_proxy="" curl --silent --fail http://localhost:4454/status/health
 ---> Using cache
 ---> d83fd5ac295f
Step 9/9 : EXPOSE 4451
 ---> Using cache
 ---> e7a655ca3b54
Successfully built e7a655ca3b54
Successfully tagged hmcts/ccd-definition-designer-api:latest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
